### PR TITLE
simplify-orderbook-api

### DIFF
--- a/src/limit.cc
+++ b/src/limit.cc
@@ -1,0 +1,45 @@
+#include <memory>
+
+#include "limit.h"
+
+
+Limit::~Limit()
+{
+    price = total_volume = size = 0;
+    head_order = tail_order = nullptr;
+    next = nullptr;
+}
+
+void Limit::addOrder(std::shared_ptr<Order> order)
+{
+    // update head and tail of limit order linked list
+    if (head_order == nullptr)
+    {
+        head_order = order;
+    }
+    else {
+        // update pointer of existing tail order
+        tail_order->next_order = order;
+    }
+
+    tail_order = order;
+    total_volume += order->remaining;
+    size++;
+    return;
+}
+
+void Limit::removeOrder(std::shared_ptr<Order> order)
+{
+    size--;
+    total_volume -= order->remaining;
+
+    if (head_order == tail_order)
+    {
+        head_order = nullptr;
+        tail_order = nullptr;
+    } else {
+        head_order = order->next_order;
+    }
+    return;
+}
+

--- a/src/limit.h
+++ b/src/limit.h
@@ -1,0 +1,33 @@
+#include <memory>
+
+#include "order.h"
+
+
+#ifndef LIMIT_H
+#define LIMIT_H
+
+/*
+* A Book level containing a list of orders at a given price-point.
+*
+* Orders are stored using shared pointers because they are referenced in a
+* number of places incl. order map, limit linked lists, etc.
+*/
+class Limit {
+public:
+    Limit(uint64_t price=0)
+        :price{price}{};
+
+    ~Limit();
+
+    void removeOrder(std::shared_ptr<Order> order);
+    void addOrder(std::shared_ptr<Order> order);
+
+    uint64_t price;
+    uint total_volume{0};
+    uint size{0};
+    std::shared_ptr<Order> head_order{nullptr};
+    std::shared_ptr<Order> tail_order{nullptr};
+    std::shared_ptr<Limit> next{nullptr};
+};
+
+#endif

--- a/src/order.cc
+++ b/src/order.cc
@@ -1,0 +1,77 @@
+#include "order.h"
+
+
+Order::Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price)
+    :id{id},
+    created_at{created_at},
+    quote_type{quote_type},
+    size{size},
+    remaining{remaining},
+    price{price}
+{}
+
+// copy constructor
+Order::Order(Order& o)
+    :id{o.id},
+    created_at{o.created_at},
+    quote_type{o.quote_type},
+    size{o.size},
+    remaining{o.remaining},
+    price{o.price}
+{}
+
+Order& Order::operator=(Order& o)
+{
+    id = o.id;
+    created_at = o.created_at;
+    quote_type = o.quote_type;
+    size = o.size;
+    remaining = o.remaining;
+    price = o.price;
+    next_order = o.next_order;
+    prev_order = o.prev_order;
+
+    o.id = o.created_at = o.size = o.remaining = o.price = 0;
+    o.next_order = o.prev_order = nullptr;
+
+    return *this;
+}
+
+// move constructor
+Order::Order(Order&& o)
+    :id{o.id},
+    created_at{o.created_at},
+    quote_type{o.quote_type},
+    size{o.size},
+    remaining{o.remaining},
+    price{o.price}
+{
+    o.id = o.created_at = o.size = o.remaining = o.price = 0;
+    o.next_order = o.prev_order = nullptr;
+}
+
+Order& Order::operator=(Order&& o)
+{
+    if (this != &o)
+    {
+        id = o.id;
+        created_at = o.created_at;
+        quote_type = o.quote_type;
+        size = o.size;
+        remaining = o.remaining;
+        price = o.price;
+        next_order = o.next_order;
+        prev_order = o.prev_order;
+
+        o.id = o.created_at = o.size = o.remaining = o.price = 0;
+        o.next_order = o.prev_order = nullptr;
+    }
+
+    return *this;
+}
+
+Order::~Order()
+{
+    id = created_at = size = remaining = price = 0;
+    next_order = prev_order = nullptr;
+}

--- a/src/order.h
+++ b/src/order.h
@@ -1,0 +1,40 @@
+#include <memory>
+
+
+#ifndef ORDER_H
+#define ORDER_H
+
+enum QuoteType {
+    BID,
+    ASK
+};
+
+/*
+* Contains all the information of a simple order.
+* Each Order is represented as a node within a linked list.
+*/
+struct Order {
+public:
+    Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price);
+
+    // copy constructor
+    Order(Order& o);
+    Order& operator=(Order& o);
+
+    // move constructor
+    Order(Order&& o);
+    Order& operator=(Order&& o);
+
+    ~Order();
+
+    uint64_t id;
+    uint64_t created_at;
+    QuoteType quote_type;
+    uint64_t size;
+    uint64_t remaining;
+    uint64_t price;
+    std::shared_ptr<Order> next_order{nullptr};
+    std::shared_ptr<Order> prev_order{nullptr};
+};
+
+#endif

--- a/src/orderbook.cc
+++ b/src/orderbook.cc
@@ -11,6 +11,73 @@ using std::shared_ptr;
 using std::chrono::milliseconds;
 
 
+Order::Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price)
+    :id{id},
+    created_at{created_at},
+    quote_type{quote_type},
+    size{size},
+    remaining{remaining},
+    price{price}
+{}
+
+Order::Order(Order& o)
+    :id{o.id},
+    created_at{o.created_at},
+    quote_type{o.quote_type},
+    size{o.size},
+    remaining{o.remaining},
+    price{o.price}
+{}
+
+Order& Order::operator=(Order& o)
+{
+    id = o.id;
+    created_at = o.created_at;
+    quote_type = o.quote_type;
+    size = o.size;
+    remaining = o.remaining;
+    price = o.price;
+    next_order = o.next_order;
+    prev_order = o.prev_order;
+
+    o.id = o.created_at = o.size = o.remaining = o.price = 0;
+    o.next_order = o.prev_order = nullptr;
+
+    return *this;
+}
+
+Order::Order(Order&& o)
+    :id{o.id},
+    created_at{o.created_at},
+    quote_type{o.quote_type},
+    size{o.size},
+    remaining{o.remaining},
+    price{o.price}
+{
+    o.id = o.created_at = o.size = o.remaining = o.price = 0;
+    o.next_order = o.prev_order = nullptr;
+}
+
+Order& Order::operator=(Order&& o)
+{
+    if (this != &o)
+    {
+        id = o.id;
+        created_at = o.created_at;
+        quote_type = o.quote_type;
+        size = o.size;
+        remaining = o.remaining;
+        price = o.price;
+        next_order = o.next_order;
+        prev_order = o.prev_order;
+
+        o.id = o.created_at = o.size = o.remaining = o.price = 0;
+        o.next_order = o.prev_order = nullptr;
+    }
+
+    return *this;
+}
+
 uint __MAX_TICK_SIZE__{8};
 
 OrderBook::OrderBook()

--- a/src/orderbook.cc
+++ b/src/orderbook.cc
@@ -6,111 +6,15 @@
 #include <iomanip>
 
 #include "orderbook.h"
+#include "order.cc"
+#include "limit.cc"
+
 
 using std::shared_ptr;
 using std::chrono::milliseconds;
 
 
-Order::Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price)
-    :id{id},
-    created_at{created_at},
-    quote_type{quote_type},
-    size{size},
-    remaining{remaining},
-    price{price}
-{}
-
-Order::Order(Order& o)
-    :id{o.id},
-    created_at{o.created_at},
-    quote_type{o.quote_type},
-    size{o.size},
-    remaining{o.remaining},
-    price{o.price}
-{}
-
-Order& Order::operator=(Order& o)
-{
-    id = o.id;
-    created_at = o.created_at;
-    quote_type = o.quote_type;
-    size = o.size;
-    remaining = o.remaining;
-    price = o.price;
-    next_order = o.next_order;
-    prev_order = o.prev_order;
-
-    o.id = o.created_at = o.size = o.remaining = o.price = 0;
-    o.next_order = o.prev_order = nullptr;
-
-    return *this;
-}
-
-Order::Order(Order&& o)
-    :id{o.id},
-    created_at{o.created_at},
-    quote_type{o.quote_type},
-    size{o.size},
-    remaining{o.remaining},
-    price{o.price}
-{
-    o.id = o.created_at = o.size = o.remaining = o.price = 0;
-    o.next_order = o.prev_order = nullptr;
-}
-
-Order& Order::operator=(Order&& o)
-{
-    if (this != &o)
-    {
-        id = o.id;
-        created_at = o.created_at;
-        quote_type = o.quote_type;
-        size = o.size;
-        remaining = o.remaining;
-        price = o.price;
-        next_order = o.next_order;
-        prev_order = o.prev_order;
-
-        o.id = o.created_at = o.size = o.remaining = o.price = 0;
-        o.next_order = o.prev_order = nullptr;
-    }
-
-    return *this;
-}
-
-Order::~Order()
-{
-    id = created_at = size = remaining = price = 0;
-    next_order = prev_order = nullptr;
-}
-
-Limit::~Limit()
-{
-    price = total_volume = size = 0;
-    head_order = tail_order = nullptr;
-    next = nullptr;
-}
-
-void Limit::addOrder(shared_ptr<Order> order)
-{
-    // update head and tail of limit order linked list
-    if (head_order == nullptr)
-    {
-        head_order = order;
-    }
-    else {
-        // update pointer of existing tail order
-        tail_order->next_order = order;
-    }
-
-    tail_order = order;
-    total_volume += order->remaining;
-    size++;
-    return;
-}
-
-
-uint __MAX_TICK_SIZE__{8};
+uint8_t __MAX_TICK_SIZE__{8};
 
 OrderBook::OrderBook()
     :tick_size{2}
@@ -270,21 +174,6 @@ uint64_t getTimestamp()
     const auto now = std::chrono::system_clock::now().time_since_epoch();
     milliseconds ms = std::chrono::duration_cast<milliseconds>(now);
     return ms.count();
-}
-
-void Limit::removeOrder(shared_ptr<Order> order)
-{
-    size--;
-    total_volume -= order->remaining;
-
-    if (head_order == tail_order)
-    {
-        head_order = nullptr;
-        tail_order = nullptr;
-    } else {
-        head_order = order->next_order;
-    }
-    return;
 }
 
 Order OrderBook::createOrder(QuoteType quote_type, uint64_t size, uint64_t remaining, double price)

--- a/src/orderbook.h
+++ b/src/orderbook.h
@@ -85,6 +85,7 @@ class OrderBook {
 
     unordered_map<uint, shared_ptr<Limit>> ask_limit_map;
     unordered_map<uint, shared_ptr<Limit>> bid_limit_map;
+
     unordered_map<uint64_t, shared_ptr<Order>> order_map;
 
     /* Use price to access limit directly via limit map */
@@ -121,7 +122,7 @@ public:
      * Attempts to fulfill incoming Order before creating limit order.
      * Returns Order id if limit order was created and 0 if fulfilled.
      */
-    uint64_t addLimitOrder(shared_ptr<Order> order, std::function<bool(uint64_t, uint64_t)> compare);
+    void addLimitOrder(Order& order, std::function<bool(uint64_t, uint64_t)> compare);
 
     uint64_t sendMarketOrder(QuoteType quote_type, uint size);
     uint64_t sendCancelOrder(uint64_t order_id);

--- a/src/orderbook.h
+++ b/src/orderbook.h
@@ -19,11 +19,17 @@ struct Limit;
 */
 struct Order {
 public:
-    Order(uint64_t id, uint64_t created_at, uint64_t size, uint64_t remaining, uint64_t price):
-    id{id}, created_at{created_at}, size{size}, remaining{remaining}, price{price}{};
+    Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price);
+
+    Order(Order& o);
+    Order& operator=(Order& o);
+
+    Order(Order&& o);
+    Order& operator=(Order&& o);
 
     uint64_t id;
     uint64_t created_at;
+    QuoteType quote_type;
     uint64_t size;
     uint64_t remaining;
     uint64_t price;

--- a/src/orderbook.h
+++ b/src/orderbook.h
@@ -78,16 +78,10 @@ class OrderBook {
     shared_ptr<Limit> getLimit(QuoteType quote_type, uint64_t price);
 
     /*
-    * Creates an Order using timestamp as the id and adds to limit.
-    * An associated Limit is created for the order if it doesn't already exist.
-    */
-    uint64_t createOrder(QuoteType quote_type, uint size, uint remaining, uint64_t price);
-
-    /*
      * Executes an Order and cleans-up order being executed.
      * Order is removed from Limit metadata and Order linked-list.
      */
-    shared_ptr<Order> execute(shared_ptr<Limit> limit, shared_ptr<Order> order);
+    shared_ptr<Order> execute(shared_ptr<Order> order);
 
     unordered_map<uint, shared_ptr<Limit>> ask_limit_map;
     unordered_map<uint, shared_ptr<Limit>> bid_limit_map;
@@ -114,7 +108,12 @@ public:
     /* Generates compare function based on QuoteType */
     std::function<bool(uint64_t, uint64_t)> buildCompareCallback(QuoteType quote_type);
 
-    void addOrder(shared_ptr<Order> order);
+    /*
+    * Creates an Order using timestamp as the id and adds to limit.
+    * An associated Limit is created for the order if it doesn't already exist.
+    */
+    Order createOrder(QuoteType quote_type, uint64_t size, uint64_t remaining, double price);
+    uint64_t addOrder(shared_ptr<Order> order);
     void removeOrder(shared_ptr<Order> order);
 
     /*
@@ -122,7 +121,7 @@ public:
      * Attempts to fulfill incoming Order before creating limit order.
      * Returns Order id if limit order was created and 0 if fulfilled.
      */
-    uint64_t sendLimitOrder(QuoteType quote_type, uint size, double price, std::function<bool(uint64_t, uint64_t)>);
+    uint64_t addLimitOrder(shared_ptr<Order> order, std::function<bool(uint64_t, uint64_t)> compare);
 
     uint64_t sendMarketOrder(QuoteType quote_type, uint size);
     uint64_t sendCancelOrder(uint64_t order_id);

--- a/src/orderbook.h
+++ b/src/orderbook.h
@@ -27,6 +27,8 @@ public:
     Order(Order&& o);
     Order& operator=(Order&& o);
 
+    ~Order();
+
     uint64_t id;
     uint64_t created_at;
     QuoteType quote_type;
@@ -43,13 +45,15 @@ public:
 * Orders are stored using shared pointers because they are referenced in a
 * number of places incl. order map, limit linked lists, etc.
 */
-struct Limit {
+class Limit {
 public:
+    Limit(uint64_t price=0)
+        :price{price}{};
+
     void removeOrder(shared_ptr<Order> order);
     void addOrder(shared_ptr<Order> order);
 
-    Limit(uint64_t price=0)
-        :price{price}{};
+    ~Limit();
 
     uint64_t price;
     uint total_volume{0};

--- a/src/orderbook.h
+++ b/src/orderbook.h
@@ -2,67 +2,12 @@
 #include <unordered_map>
 #include <functional>
 
+#include "order.h"
+#include "limit.h"
+
+
 using std::shared_ptr;
 using std::unordered_map;
-
-
-enum QuoteType {
-    BID,
-    ASK
-};
-
-struct Limit;
-
-/*
-* Contains all the information of a simple order.
-* Each Order is represented as a node within a linked list.
-*/
-struct Order {
-public:
-    Order(uint64_t id, uint64_t created_at, QuoteType quote_type, uint64_t size, uint64_t remaining, uint64_t price);
-
-    Order(Order& o);
-    Order& operator=(Order& o);
-
-    Order(Order&& o);
-    Order& operator=(Order&& o);
-
-    ~Order();
-
-    uint64_t id;
-    uint64_t created_at;
-    QuoteType quote_type;
-    uint64_t size;
-    uint64_t remaining;
-    uint64_t price;
-    shared_ptr<Order> next_order{nullptr};
-    shared_ptr<Order> prev_order{nullptr};
-};
-
-/*
-* A Book level containing a list of orders at a given price-point.
-*
-* Orders are stored using shared pointers because they are referenced in a
-* number of places incl. order map, limit linked lists, etc.
-*/
-class Limit {
-public:
-    Limit(uint64_t price=0)
-        :price{price}{};
-
-    void removeOrder(shared_ptr<Order> order);
-    void addOrder(shared_ptr<Order> order);
-
-    ~Limit();
-
-    uint64_t price;
-    uint total_volume{0};
-    uint size{0};
-    shared_ptr<Order> head_order{nullptr};
-    shared_ptr<Order> tail_order{nullptr};
-    shared_ptr<Limit> next{nullptr};
-};
-
 
 /*
 * A directory containing levels of bids and asks respectively.

--- a/tests/unittests.cc
+++ b/tests/unittests.cc
@@ -6,7 +6,6 @@
 
 using std::function;
 
-
 // TODO: write market order and cancel order tests
 
 TEST(OrderBookTest, TestOrderBookInitialize)
@@ -36,151 +35,153 @@ TEST(OrderBookTest, TestOrderBookDefaultTickSize)
 
     function<bool(double, double)> bid_compare;
     bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100.4564, bid_compare);
+
+    Order&& order = orderbook.createOrder(QuoteType::BID, 10, 10, 100.4564);
+    orderbook.addLimitOrder(std::make_shared<Order>(order), bid_compare);
 
     ASSERT_EQ(orderbook.size(), 1);
     ASSERT_EQ(orderbook.getInsideBid(), 10046);
 }
 
-TEST(OrderBookTest, TestOrderBookTickSize)
-{
-    OrderBook orderbook{4};
+/* TEST(OrderBookTest, TestOrderBookTickSize) */
+/* { */
+/*     OrderBook orderbook{4}; */
 
-    function<bool(double, double)> bid_compare;
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100.4564, bid_compare);
+/*     function<bool(double, double)> bid_compare; */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100.4564, bid_compare); */
 
-    std::cout << orderbook.getInsideBid();
+/*     std::cout << orderbook.getInsideBid(); */
 
-    ASSERT_EQ(orderbook.size(), 1);
-    ASSERT_EQ(orderbook.getInsideBid(), 1004564);
-}
+/*     ASSERT_EQ(orderbook.size(), 1); */
+/*     ASSERT_EQ(orderbook.getInsideBid(), 1004564); */
+/* } */
 
-TEST(OrderBookTest, TestOrderBookBidCreate)
-{
+/* TEST(OrderBookTest, TestOrderBookBidCreate) */
+/* { */
 
-    OrderBook orderbook;
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    orderbook.sendLimitOrder(QuoteType::BID, 1, 80, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::BID, 1, 90, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::BID, 1, 100, bid_compare);
+/*     orderbook.addLimitOrder(QuoteType::BID, 1, 80, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 1, 90, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 1, 100, bid_compare); */
 
-    ASSERT_TRUE(orderbook.size() == 3);
-    ASSERT_TRUE(orderbook.getInsideBid() == 10000);
-}
+/*     ASSERT_TRUE(orderbook.size() == 3); */
+/*     ASSERT_TRUE(orderbook.getInsideBid() == 10000); */
+/* } */
 
-TEST(OrderBookTest, TestOrderBookAskCreate)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestOrderBookAskCreate) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
 
-    orderbook.sendLimitOrder(QuoteType::ASK, 1, 80, ask_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 1, 90, ask_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 1, 100, ask_compare);
+/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 80, ask_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 90, ask_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 100, ask_compare); */
 
-    ASSERT_TRUE(orderbook.size() == 3);
-    ASSERT_TRUE(orderbook.getInsideAsk() == 8000);
-}
+/*     ASSERT_TRUE(orderbook.size() == 3); */
+/*     ASSERT_TRUE(orderbook.getInsideAsk() == 8000); */
+/* } */
 
-TEST(OrderBookTest, TestSingleBidAskExecute)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestSingleBidAskExecute) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    // test single bid-ask execution
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 10, 100, ask_compare);
+/*     // test single bid-ask execution */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
 
-    ASSERT_TRUE(orderbook.size() == 0);
-    ASSERT_TRUE(orderbook.getInsideBid() == 0);
-    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
-}
+/*     ASSERT_TRUE(orderbook.size() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
+/* } */
 
-TEST(OrderBookTest, TestMultipleAskBidExecute)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestMultipleAskBidExecute) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    // test multiple ask to bid execution
-    orderbook.sendLimitOrder(QuoteType::BID, 20, 100, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 10, 100, ask_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 10, 100, ask_compare);
+/*     // test multiple ask to bid execution */
+/*     orderbook.addLimitOrder(QuoteType::BID, 20, 100, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
 
-    ASSERT_TRUE(orderbook.size() == 0);
-    ASSERT_TRUE(orderbook.getInsideBid() == 0);
-    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
-}
+/*     ASSERT_TRUE(orderbook.size() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
+/* } */
 
-TEST(OrderBookTest, TestMultipleBidAskExecute)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestMultipleBidAskExecute) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    // test multiple bid to ask execution
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 20, 100, ask_compare);
+/*     // test multiple bid to ask execution */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 20, 100, ask_compare); */
 
-    ASSERT_TRUE(orderbook.size() == 0);
-    ASSERT_TRUE(orderbook.getInsideBid() == 0);
-    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
-}
+/*     ASSERT_TRUE(orderbook.size() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
+/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
+/* } */
 
-TEST(OrderBookTest, TestPartialAskExecution)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestPartialAskExecution) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    // test partial ask execution
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 100, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 20, 100, ask_compare);
+/*     // test partial ask execution */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 20, 100, ask_compare); */
 
-    ASSERT_EQ(orderbook.size(), 1);
-    ASSERT_EQ(orderbook.getInsideBid(), 0);
-    ASSERT_EQ(orderbook.getInsideAsk(), 10000);
-    ASSERT_EQ(orderbook.getInsideAskSize(), 10);
-}
+/*     ASSERT_EQ(orderbook.size(), 1); */
+/*     ASSERT_EQ(orderbook.getInsideBid(), 0); */
+/*     ASSERT_EQ(orderbook.getInsideAsk(), 10000); */
+/*     ASSERT_EQ(orderbook.getInsideAskSize(), 10); */
+/* } */
 
-TEST(OrderBookTest, TestPartialBidExecution)
-{
-    OrderBook orderbook;
+/* TEST(OrderBookTest, TestPartialBidExecution) */
+/* { */
+/*     OrderBook orderbook; */
 
-    function<bool(double, double)> bid_compare;
-    function<bool(double, double)> ask_compare;
-    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
-    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+/*     function<bool(double, double)> bid_compare; */
+/*     function<bool(double, double)> ask_compare; */
+/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
 
-    // test partial bid execution
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 80, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::BID, 10, 90, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::BID, 15, 90, bid_compare);
-    orderbook.sendLimitOrder(QuoteType::ASK, 40, 90, ask_compare);
+/*     // test partial bid execution */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 80, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 10, 90, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::BID, 15, 90, bid_compare); */
+/*     orderbook.addLimitOrder(QuoteType::ASK, 40, 90, ask_compare); */
 
-    ASSERT_EQ(orderbook.size(), 2);
-    ASSERT_EQ(orderbook.getInsideBid(), 8000);
-    ASSERT_EQ(orderbook.getInsideAsk(), 9000);
-    ASSERT_EQ(orderbook.getInsideAskSize(), 15);
-    ASSERT_EQ(orderbook.getInsideBidSize(), 10);
-}
+/*     ASSERT_EQ(orderbook.size(), 2); */
+/*     ASSERT_EQ(orderbook.getInsideBid(), 8000); */
+/*     ASSERT_EQ(orderbook.getInsideAsk(), 9000); */
+/*     ASSERT_EQ(orderbook.getInsideAskSize(), 15); */
+/*     ASSERT_EQ(orderbook.getInsideBidSize(), 10); */
+/* } */
 

--- a/tests/unittests.cc
+++ b/tests/unittests.cc
@@ -36,152 +36,180 @@ TEST(OrderBookTest, TestOrderBookDefaultTickSize)
     function<bool(double, double)> bid_compare;
     bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-    Order&& order = orderbook.createOrder(QuoteType::BID, 10, 10, 100.4564);
-    orderbook.addLimitOrder(std::make_shared<Order>(order), bid_compare);
+    Order o1 = orderbook.createOrder(QuoteType::BID, 10, 10, 100.4564);
+    orderbook.addLimitOrder(o1, bid_compare);
 
     ASSERT_EQ(orderbook.size(), 1);
     ASSERT_EQ(orderbook.getInsideBid(), 10046);
 }
 
-/* TEST(OrderBookTest, TestOrderBookTickSize) */
-/* { */
-/*     OrderBook orderbook{4}; */
+TEST(OrderBookTest, TestOrderBookTickSize)
+{
+    OrderBook orderbook{4};
 
-/*     function<bool(double, double)> bid_compare; */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100.4564, bid_compare); */
+    function<bool(double, double)> bid_compare;
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/*     std::cout << orderbook.getInsideBid(); */
+    Order o1 = orderbook.createOrder(QuoteType::BID, 10, 10, 100.4564);
+    orderbook.addLimitOrder(o1, bid_compare);
 
-/*     ASSERT_EQ(orderbook.size(), 1); */
-/*     ASSERT_EQ(orderbook.getInsideBid(), 1004564); */
-/* } */
+    std::cout << orderbook.getInsideBid();
 
-/* TEST(OrderBookTest, TestOrderBookBidCreate) */
-/* { */
+    ASSERT_EQ(orderbook.size(), 1);
+    ASSERT_EQ(orderbook.getInsideBid(), 1004564);
+}
 
-/*     OrderBook orderbook; */
+TEST(OrderBookTest, TestOrderBookBidCreate)
+{
+    OrderBook orderbook;
 
-/*     function<bool(double, double)> bid_compare; */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+    function<bool(double, double)> bid_compare;
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/*     orderbook.addLimitOrder(QuoteType::BID, 1, 80, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 1, 90, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 1, 100, bid_compare); */
+    Order o1 = orderbook.createOrder(QuoteType::BID, 1, 1, 80);
+    Order o2 = orderbook.createOrder(QuoteType::BID, 1, 1, 90);
+    Order o3 = orderbook.createOrder(QuoteType::BID, 1, 1, 100);
 
-/*     ASSERT_TRUE(orderbook.size() == 3); */
-/*     ASSERT_TRUE(orderbook.getInsideBid() == 10000); */
-/* } */
+    orderbook.addLimitOrder(o1, bid_compare);
+    orderbook.addLimitOrder(o2, bid_compare);
+    orderbook.addLimitOrder(o3, bid_compare);
 
-/* TEST(OrderBookTest, TestOrderBookAskCreate) */
-/* { */
-/*     OrderBook orderbook; */
+    ASSERT_TRUE(orderbook.size() == 3);
+    ASSERT_TRUE(orderbook.getInsideBid() == 10000);
+}
 
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
+TEST(OrderBookTest, TestOrderBookAskCreate)
+{
+    OrderBook orderbook;
 
-/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 80, ask_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 90, ask_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 1, 100, ask_compare); */
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
 
-/*     ASSERT_TRUE(orderbook.size() == 3); */
-/*     ASSERT_TRUE(orderbook.getInsideAsk() == 8000); */
-/* } */
+    Order o1 = orderbook.createOrder(QuoteType::ASK, 1, 1, 80);
+    Order o2 = orderbook.createOrder(QuoteType::ASK, 1, 1, 90);
+    Order o3 = orderbook.createOrder(QuoteType::ASK, 1, 1, 100);
 
-/* TEST(OrderBookTest, TestSingleBidAskExecute) */
-/* { */
-/*     OrderBook orderbook; */
+    orderbook.addLimitOrder(o1, ask_compare);
+    orderbook.addLimitOrder(o2, ask_compare);
+    orderbook.addLimitOrder(o3, ask_compare);
 
-/*     function<bool(double, double)> bid_compare; */
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+    ASSERT_TRUE(orderbook.size() == 3);
+    ASSERT_TRUE(orderbook.getInsideAsk() == 8000);
+}
 
-/*     // test single bid-ask execution */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
+TEST(OrderBookTest, TestSingleBidAskExecute)
+{
+    OrderBook orderbook;
 
-/*     ASSERT_TRUE(orderbook.size() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
-/* } */
+    function<bool(double, double)> bid_compare;
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/* TEST(OrderBookTest, TestMultipleAskBidExecute) */
-/* { */
-/*     OrderBook orderbook; */
+    Order o1 = orderbook.createOrder(QuoteType::ASK, 10, 10, 100);
+    Order o2 = orderbook.createOrder(QuoteType::BID, 10, 10, 100);
 
-/*     function<bool(double, double)> bid_compare; */
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+    // test single bid-ask execution
+    orderbook.addLimitOrder(o1, ask_compare);
+    orderbook.addLimitOrder(o2, bid_compare);
 
-/*     // test multiple ask to bid execution */
-/*     orderbook.addLimitOrder(QuoteType::BID, 20, 100, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 10, 100, ask_compare); */
+    ASSERT_TRUE(orderbook.size() == 0);
+    ASSERT_TRUE(orderbook.getInsideBid() == 0);
+    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
+}
 
-/*     ASSERT_TRUE(orderbook.size() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
-/* } */
+TEST(OrderBookTest, TestMultipleAskBidExecute)
+{
+    OrderBook orderbook;
 
-/* TEST(OrderBookTest, TestMultipleBidAskExecute) */
-/* { */
-/*     OrderBook orderbook; */
+    function<bool(double, double)> bid_compare;
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/*     function<bool(double, double)> bid_compare; */
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+    Order o1 = orderbook.createOrder(QuoteType::BID, 20, 20, 100);
+    Order o2 = orderbook.createOrder(QuoteType::ASK, 10, 10, 100);
+    Order o3 = orderbook.createOrder(QuoteType::ASK, 10, 10, 100);
 
-/*     // test multiple bid to ask execution */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 20, 100, ask_compare); */
+    // test multiple ask to bid execution
+    orderbook.addLimitOrder(o1, bid_compare);
+    orderbook.addLimitOrder(o2, ask_compare);
+    orderbook.addLimitOrder(o3, ask_compare);
 
-/*     ASSERT_TRUE(orderbook.size() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideBid() == 0); */
-/*     ASSERT_TRUE(orderbook.getInsideAsk() == 0); */
-/* } */
+    ASSERT_TRUE(orderbook.size() == 0);
+    ASSERT_TRUE(orderbook.getInsideBid() == 0);
+    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
+}
 
-/* TEST(OrderBookTest, TestPartialAskExecution) */
-/* { */
-/*     OrderBook orderbook; */
+TEST(OrderBookTest, TestMultipleBidAskExecute)
+{
+    OrderBook orderbook;
 
-/*     function<bool(double, double)> bid_compare; */
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+    function<bool(double, double)> bid_compare;
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/*     // test partial ask execution */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 100, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 20, 100, ask_compare); */
+    Order o1 = orderbook.createOrder(QuoteType::ASK, 20, 20, 100);
+    Order o2 = orderbook.createOrder(QuoteType::BID, 10, 10, 100);
+    Order o3 = orderbook.createOrder(QuoteType::BID, 10, 10, 100);
 
-/*     ASSERT_EQ(orderbook.size(), 1); */
-/*     ASSERT_EQ(orderbook.getInsideBid(), 0); */
-/*     ASSERT_EQ(orderbook.getInsideAsk(), 10000); */
-/*     ASSERT_EQ(orderbook.getInsideAskSize(), 10); */
-/* } */
+    // test multiple bid to ask execution
+    orderbook.addLimitOrder(o1, ask_compare);
+    orderbook.addLimitOrder(o2, bid_compare);
+    orderbook.addLimitOrder(o3, bid_compare);
 
-/* TEST(OrderBookTest, TestPartialBidExecution) */
-/* { */
-/*     OrderBook orderbook; */
+    ASSERT_TRUE(orderbook.size() == 0);
+    ASSERT_TRUE(orderbook.getInsideBid() == 0);
+    ASSERT_TRUE(orderbook.getInsideAsk() == 0);
+}
 
-/*     function<bool(double, double)> bid_compare; */
-/*     function<bool(double, double)> ask_compare; */
-/*     ask_compare = orderbook.buildCompareCallback(QuoteType::ASK); */
-/*     bid_compare = orderbook.buildCompareCallback(QuoteType::BID); */
+TEST(OrderBookTest, TestPartialAskExecution)
+{
+    OrderBook orderbook;
 
-/*     // test partial bid execution */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 80, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 10, 90, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::BID, 15, 90, bid_compare); */
-/*     orderbook.addLimitOrder(QuoteType::ASK, 40, 90, ask_compare); */
+    function<bool(double, double)> bid_compare;
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
 
-/*     ASSERT_EQ(orderbook.size(), 2); */
-/*     ASSERT_EQ(orderbook.getInsideBid(), 8000); */
-/*     ASSERT_EQ(orderbook.getInsideAsk(), 9000); */
-/*     ASSERT_EQ(orderbook.getInsideAskSize(), 15); */
-/*     ASSERT_EQ(orderbook.getInsideBidSize(), 10); */
-/* } */
+    Order o1 = orderbook.createOrder(QuoteType::ASK, 20, 20, 100);
+    Order o2 = orderbook.createOrder(QuoteType::BID, 10, 10, 100);
+
+    // test partial ask execution
+    orderbook.addLimitOrder(o1, ask_compare);
+    orderbook.addLimitOrder(o2, bid_compare);
+
+    ASSERT_EQ(orderbook.size(), 1);
+    ASSERT_EQ(orderbook.getInsideBid(), 0);
+    ASSERT_EQ(orderbook.getInsideAsk(), 10000);
+    ASSERT_EQ(orderbook.getInsideAskSize(), 10);
+}
+
+TEST(OrderBookTest, TestPartialBidExecution)
+{
+    OrderBook orderbook;
+
+    function<bool(double, double)> bid_compare;
+    function<bool(double, double)> ask_compare;
+    ask_compare = orderbook.buildCompareCallback(QuoteType::ASK);
+    bid_compare = orderbook.buildCompareCallback(QuoteType::BID);
+
+    Order o1 = orderbook.createOrder(QuoteType::BID, 10, 10, 80);
+    Order o2 = orderbook.createOrder(QuoteType::BID, 10, 10, 90);
+    Order o3 = orderbook.createOrder(QuoteType::BID, 15, 15, 90);
+    Order o4 = orderbook.createOrder(QuoteType::ASK, 40, 40, 90);
+
+    // test partial bid execution
+    orderbook.addLimitOrder(o1, bid_compare);
+    orderbook.addLimitOrder(o2, bid_compare);
+    orderbook.addLimitOrder(o3, bid_compare);
+    orderbook.addLimitOrder(o4, ask_compare);
+
+    ASSERT_EQ(orderbook.size(), 2);
+    ASSERT_EQ(orderbook.getInsideBid(), 8000);
+    ASSERT_EQ(orderbook.getInsideAsk(), 9000);
+    ASSERT_EQ(orderbook.getInsideAskSize(), 15);
+    ASSERT_EQ(orderbook.getInsideBidSize(), 10);
+}
 


### PR DESCRIPTION
## Summary

- Simplify api for methods that interact with `Order` objects
- Add destructors for `Order` and `Limit`
- Move `Order` and `Limit` into their own header files